### PR TITLE
Fix admin/customer/index&&show pages

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -3,8 +3,7 @@ class Admin::CustomersController < ApplicationController
   # before_action :authenticate_admin
 
   def index
-    # @customers = Customer.all kaminari使用の為
-    @customers = Customer.page(params[:page]).reverse_order
+    @customers = Customer.page(params[:page]).per(5).order(id:"ASC")
   end
 
   def show

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -7,15 +7,15 @@ class Admin::CustomersController < ApplicationController
   end
 
   def show
-    @customer = Customer.find(params[:id])
+    @customer = current_customer
   end
 
   def edit
-     @customer = Customer.find(params[:id])
+     @customer = current_customer
   end
 
   def update
-    @customer = Customer.find(params[:id])
+    @customer = current_customer
     @customer.update(customer_params)
     redirect_to admin_customer_path(@customer.id)
   end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -9,6 +9,8 @@ class Public::OrdersController < ApplicationController
     @order_day = @customer.created_order
     @delivery_address = DelivertAddress.find(params[:delivery_address_id])
   end
+  
+  
   # before_action :authenticate_customer!
 
   def new

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -1,5 +1,6 @@
+
 <h2>会員一覧</h2>
-<div class = "row">
+<!--<div class = "row">-->
   <table>
     <thead>
       <tr>
@@ -12,13 +13,16 @@
     <tbody>
       <% @customers.each do |customer| %>
       <tr>
-        <td><%= custemer.id %></td>
-        <td><%= custemer.last_name %> <%= custemer.first_name %></td>
-        <td><%= custemer.emai %></td>
-        <td><%= is_delete %></td>
+        <td><%= customer.id %></td>
+        <td>
+          <%= link_to "/customers/my_page" do %>
+            <%= customer.last_name %> <%= customer.first_name %></td>
+          <% end %>git 
+        <td><%= customer.email %></td>
+        <td><%= customer.is_delete %></td>
       </tr>
       <% end %>
     </tbody>
   </table>
   <%= paginate @customers %>
-</div>
+<!--</div>-->

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -15,9 +15,9 @@
       <tr>
         <td><%= customer.id %></td>
         <td>
-          <%= link_to "/customers/my_page" do %>
+          <%= link_to "/admin/customers/:id" do %>
             <%= customer.last_name %> <%= customer.first_name %></td>
-          <% end %>git 
+          <% end %>
         <td><%= customer.email %></td>
         <td><%= customer.is_delete %></td>
       </tr>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -1,4 +1,4 @@
-<h2><%= @custemer.id %>さんの会員詳細</h2>
+<h2><%= @customer.last_name %> <%= @customer.first_name %>さんの会員詳細</h2>
 
 <table>
   <tbody>
@@ -8,33 +8,38 @@
     </tr>
     <tr>
       <th>氏名</th>
-      <td><%= @custemer.last_name %> <%= @custemer.first_name %></td>
+      <td><%= @customer.last_name %> <%= @customer.first_name %></td>
     </tr>
     <tr>
       <th>フリガナ</th>
-      <td><%= @custemer.last_name_kana %> <%= @custemer.first_name_kana %></td>
+      <td><%= @customer.last_name_kana %> <%= @customer.first_name_kana %></td>
     </tr>
     <tr>
       <th>郵便番号</th>
-      <td><%= @custemer.postcode %></td>
+      <td><%= @customer.postcode %></td>
     </tr>
     <tr>
       <th>住所</th>
-      <td><%= @custemer.address %></td>
+      <td><%= @customer.address %></td>
     </tr>
       <tr>
       <th>電話番号</th>
-      <td><%= @custemer.phone_number %></td>
+      <td><%= @customer.phone_number %></td>
     </tr>
       <tr>
       <th>メールアドレス</th>
-      <td><%= @custemer.email %></td>
+      <td><%= @customer.email %></td>
     </tr>
     <tr>
       <th>会員ステータス</th>
-      <td><%= @custemer.is_delete %></td>
+      <td><%= @customer.is_delete %></td>
+    </tr>
+    <tr>
+      <td><%= link_to "編集する", edit_admin_customer_path, class:"btn btn-success text-white" %></td>
+      <td><%= link_to "注文履歴一覧を見る", "", class:"btn btn-primary text-white" %></td>
     </tr>
   </tbody>
-    <%= link_to "編集する", edit_admin_customer_path, class:"p-3 mb-2 bg-success text-white" %>
-    <%= link_to "注文履歴一覧を見る", _path, class:"p-3 mb-2 bg-primary text-white" %>
 </table>
+
+
+      

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -1,0 +1,27 @@
+<div class='container px-5 px-sm-0'>
+  <div class='row'>
+    <h2>注文履歴一覧</h2>
+    <table class='table table-bordered'>
+      <thead>
+        <tr>
+          <th>注文日</th>
+          <th>配送先</th>
+          <th>注文商品</th>
+          <th>ステータス</th>
+          <th>注文詳細</th>
+        </tr>
+      </thead>
+      <tbody>
+        < @orders.erch do |order| %>
+        <tr>
+          <td><= link_to order.created_at, order_path(@order) %></td>
+          <td><= order.customer_id.name %></td>
+          <td><= order.quantity %></td>
+          <td><= order.order_status %></td>
+        </tr>
+        < end %>
+      </tbody>
+    </table>
+    <%= paginate @orders %>
+  </div>
+</div>

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -6,3 +6,5 @@
 #     https: false
 #   )
 # end
+
+Refile.secret_key = 'd9705a788024d5b4a278e0c829bb03c61dd169c7c08824e307b6f9a3fc8ee22c01fa1a48484005e6ee64f23ce1351de6d3f6357b839c29d1d20ce5daf927d14c'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,12 +4,12 @@ Rails.application.routes.draw do
     sessions: 'customers/sessions'
   }
 
-  
+
     devise_for :admins, controllers: {
     registrations: 'adimins/registrations',
     sessions: 'adimins/sessions'
   }
-  
+
 
   namespace :admin do
     resources :homes


### PR DESCRIPTION
【変更点】
・customerのスペルミス修正
・各コントローラーのインスタンス変数の定義変更
・会員一覧の氏名リンクから管理者会員詳細に飛べるよう設定


【ポイント】
・みなさんもマージ後プルして頂ければ、管理者の会員一覧と詳細見れると思います！

【注意点】
・まだ、管理者会員詳細の編集と注文履歴一覧飛べません、このあと修正します！
